### PR TITLE
Update additional-packages.cfg

### DIFF
--- a/all/debian/cfg.d/additional-packages.cfg
+++ b/all/debian/cfg.d/additional-packages.cfg
@@ -43,7 +43,7 @@ description;texlive-lang-all;This package pulls in all texlive-lang-*
 description;texlive-lang-all;packages.
 #
 # texlive-fonts-extra-links
-title;texlive-fonts-extra-extra-links;Setup of fonts for TeX Live and search via kpathsea
+title;texlive-fonts-extra-links;Setup of fonts for TeX Live and search via kpathsea
 description;texlive-fonts-extra-links;This package ships links to all the fonts that are originally in
 description;texlive-fonts-extra-links;TeX Live, collection fonts-extra, but are not shipped in the Debian
 description;texlive-fonts-extra-links;package texlive-fonts-extra due to availability in separate 


### PR DESCRIPTION
fix extra word. This bug will cause missing short description when `apt search texlive-fonts-extra-links`